### PR TITLE
Command line argument parsing. Allow multiple instances of '-B'.

### DIFF
--- a/pynagio/__init__.py
+++ b/pynagio/__init__.py
@@ -47,7 +47,7 @@ class PynagioCheck(object):
         self.parser.add_argument("-R", nargs='+', dest="rate_regexes",
                                  help="Rates regex to calculate")
         self.parser.add_argument("-B", nargs='+', dest="blacklist_regexes",
-                                 help="Blacklist regexes")
+                                 help="Blacklist regexes", action="extend")
 
     def add_option(self, *args, **kwargs):
         self.parser.add_argument(*args, **kwargs)


### PR DESCRIPTION
Command line argument parsing. Allow multiple instances of '-B'.