### PR TITLE
Revert "Command line argument parsing. Allow multiple instances of '-…

### DIFF
--- a/pynagio/__init__.py
+++ b/pynagio/__init__.py
@@ -47,7 +47,7 @@ class PynagioCheck(object):
         self.parser.add_argument("-R", nargs='+', dest="rate_regexes",
                                  help="Rates regex to calculate")
         self.parser.add_argument("-B", nargs='+', dest="blacklist_regexes",
-                                 help="Blacklist regexes", action="extend")
+                                 help="Blacklist regexes")
 
     def add_option(self, *args, **kwargs):
         self.parser.add_argument(*args, **kwargs)


### PR DESCRIPTION
…B'."

This reverts commit 590cd1fc2fcd3075babd869a29d639193c22ef72.

Problems with Python versions below 3.8.